### PR TITLE
Fix username/virtual address on server metrics

### DIFF
--- a/openvpn_exporter.go
+++ b/openvpn_exporter.go
@@ -58,8 +58,8 @@ var (
 				"Common Name",
 				"Connected Since (time_t)",
 				"Real Address",
-				"Username",
 				"Virtual Address",
+				"Username",
 			},
 			Metrics: []OpenvpnServerHeaderField{
 				OpenvpnServerHeaderField{


### PR DESCRIPTION
`username` and `virtual_address` labels are swapped on server metrics:

```
$ ./prom-openvpn-exporter -openvpn.status_paths examples/server3.status

openvpn_server_client_received_bytes_total{...,username="0.0.0.0",virtual_address="UNDEF"} 6.93438277e+08
```