### PR TITLE
Use multi-stage docker build, add simple Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.8-alpine
+WORKDIR /go/src/app
+RUN apk --no-cache add git
+COPY openvpn_exporter.go .
+RUN go get -d ./...
+# Build *really static*
+ENV CGO_ENABLED 0
+RUN go build -ldflags '-s' openvpn_exporter.go
+
+# This requires Docker version 17.05 or newer
+FROM scratch
+COPY --from=0 /go/src/app/openvpn_exporter /bin/openvpn_exporter
+ENTRYPOINT ["/bin/openvpn_exporter"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+
+repository := openvpn_exporter
+git_rev := $(shell git describe --always --tags)
+img := $(repository):$(git_rev)
+temp_container := openvpn_exporter-tmp-$(git_rev)
+
+openvpn_exporter: docker_image clean_temp_container
+	docker run --rm -d -v "$(CURDIR):/target" --name "$(temp_container)" "$(img)" -h
+	docker cp "$(temp_container):/bin/openvpn_exporter" .
+
+docker_image: openvpn_exporter.go Dockerfile
+	docker build -t "$(img)" .
+
+clean: clean_temp_container
+	rm -f openvpn_exporter
+	if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "$(img)"; then \
+		docker rmi "$(img)"; \
+	fi
+
+clean_temp_container:
+	if docker ps -a --format '{{.Names}}' | grep -q "$(temp_container)"; then \
+		docker rm -f "$(temp_container)"; \
+	fi
+
+.PHONY: clean docker_image

--- a/build_static.sh
+++ b/build_static.sh
@@ -1,17 +1,2 @@
 #!/bin/sh
-
-docker run -i -v `pwd`:/openvpn_exporter alpine:edge /bin/sh << 'EOF'
-set -ex
-
-# Install prerequisites for the build process.
-apk update
-apk add ca-certificates git go libc-dev
-update-ca-certificates
-
-# Build the openvpn_exporter.
-cd /openvpn_exporter
-export GOPATH=/gopath
-go get -d ./...
-go build --ldflags '-extldflags "-static"'
-strip openvpn_exporter
-EOF
+make static


### PR DESCRIPTION
I added a Dockerfile build to make it easier to set up a quay.io or hub.docker.com autobuilder for this project, and a Makefile to tie the developer flow together cleanly.

This also sets CGO_ENABLED=0 so the final resulting binary is *really* statically linked, without dynamically depending on musl or glibc or anything else.