### PR TITLE
Add status_path label to connected_clients server metric.

### DIFF
--- a/openvpn_exporter.go
+++ b/openvpn_exporter.go
@@ -55,7 +55,8 @@ var (
 	// Metrics specific to OpenVPN servers.
 	openvpnConnectedClientsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName("openvpn", "", "openvpn_server_connected_clients"),
-		"Number Of Connected Clients", nil, nil)
+		"Number Of Connected Clients",
+		[]string{"status_path"}, nil)
 
 	openvpnServerHeaders = map[string]OpenvpnServerHeader{
 		"CLIENT_LIST": {
@@ -248,7 +249,8 @@ func CollectServerStatusFromReader(statusPath string, file io.Reader, ch chan<- 
 	ch <- prometheus.MustNewConstMetric(
 		openvpnConnectedClientsDesc,
 		prometheus.GaugeValue,
-		float64(numberConnectedClient))
+		float64(numberConnectedClient),
+		statusPath)
 	return scanner.Err()
 }
 


### PR DESCRIPTION
This fixes an issue where the exporter would fail to work if a user
attempted to monitor multiple OpenVPN processes in server mode as the
metrics would clash without the status_path label.
This resulted in the exporter failing and returning a HTTP 500.

Before the fix:

```
# curl -I localhost:9176/metrics
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Tue, 01 May 2018 11:06:28 GMT
Content-Length: 182
```

```
# curl localhost:9176/metrics
An error has occurred during metrics gathering:

collected metric openvpn_openvpn_server_connected_clients gauge:<value:2 >  was collected before with the same name and label values
```

After fix:

```
# curl localhost:9176/metrics 2>/dev/null | grep connected_clients
# HELP openvpn_openvpn_server_connected_clients Number Of Connected Clients
# TYPE openvpn_openvpn_server_connected_clients gauge
openvpn_openvpn_server_connected_clients{status_path="/var/log/openvpn-status-server.log"} 1
openvpn_openvpn_server_connected_clients{status_path="/var/log/openvpn-status-server2.log"} 1
```