### PR TITLE
fix: correct typo in connected client metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var (
 
 	// Metrics specific to OpenVPN servers.
 	openvpnConnectedClientsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("openvpn", "", "openvpn_server_connected_clients"),
+		prometheus.BuildFQName("openvpn", "", "server_connected_clients"),
 		"Number Of Connected Clients",
 		[]string{"status_path"}, nil)
 


### PR DESCRIPTION
Before the metric was called `openvpn_openvpn_server_connected_clients`