### PR TITLE
  OpenVPN "Access Server" Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ multiple status files, using the `-openvpn.status_paths` command line
 flag. Paths need to be comma separated. Metrics for all status files are
 exported over TCP port 9176.
 
+The exporter also supports the OpenVPN "Access Server" via `sacli VPNStatus` 
+the "Access Server Client API" command. Use the `-openvpn.status_type api` 
+command line flag to enable this mode and get the status from all of the 
+OpenVPN processes running on the Access Server. In "api" mode the 
+`-openvpn.status_paths` files are not used.
+
 Please refer to this utility's `main()` function for a full list of
 supported command line flags.
 
@@ -60,26 +66,42 @@ Usage of openvpn_exporter:
 ```sh
   -openvpn.status_paths string
     	Paths at which OpenVPN places its status files. (default "examples/client.status,examples/server2.status,examples/server3.status")
+  -openvpn.status_type string
+      Type of OpenVPN status, either "file" (personal vpn) or "api" (access server). (default "file")
   -web.listen-address string
     	Address to listen on for web interface and telemetry. (default ":9176")
   -web.telemetry-path string
     	Path under which to expose metrics. (default "/metrics")
 ```
 
-E.g:
+## Execution
 
+OpenVPN Personal:
 ```sh
 openvpn_exporter -openvpn.status_paths /etc/openvpn/openvpn-status.log
+```
+
+OpenVPN Access Server:
+```sh
+openvpn_exporter -openvpn.status_type api
 ```
 
 ## Docker
 
 To use with docker you must mount your status file to `/etc/openvpn_exporter/server.status`.
 
+OpenVPN Personal:
 ```sh
 docker run -p 9176:9176 \
   -v /path/to/openvpn_server.status:/etc/openvpn_exporter/server.status \
   kumina/openvpn-exporter -openvpn.status_paths /etc/openvpn_exporter/server.status
+```
+
+OpenVPN Access Server:
+```sh
+docker run -p 9176:9176 \
+  -v /usr/local/openvpn_as/scripts:/usr/local/openvpn_as/scripts \
+  kumina/openvpn-exporter -openvpn.status_paths api
 ```
 
 Metrics should be available at http://localhost:9176/metrics.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ multiple status files, using the `-openvpn.status_paths` command line
 flag. Paths need to be comma separated. Metrics for all status files are
 exported over TCP port 9176.
 
-The exporter also supports the OpenVPN "Access Server" via `sacli VPNStatus` 
+The exporter also supports the OpenVPN "Access Server" via `sacli VPNStatus`, 
 the "Access Server Client API" command. Use the `-openvpn.status_type api` 
 command line flag to enable this mode and get the status from all of the 
 OpenVPN processes running on the Access Server. In "api" mode the 
@@ -101,7 +101,7 @@ OpenVPN Access Server:
 ```sh
 docker run -p 9176:9176 \
   -v /usr/local/openvpn_as/scripts:/usr/local/openvpn_as/scripts \
-  kumina/openvpn-exporter -openvpn.status_paths api
+  kumina/openvpn-exporter -openvpn.status_type api
 ```
 
 Metrics should be available at http://localhost:9176/metrics.

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ var (
 		"UNIX timestamp at which the OpenVPN statistics were updated.",
 		[]string{"status_path", "instance_id"}, nil)
 	openvpnStatusApiBuildInfo = prometheus.NewDesc(
-		prometheus.BuildFQName("openvpn", "", "build_info"),
+		prometheus.BuildFQName("openvpn", "", "server_build_info"),
 		"application and build information on the running OpenVPN system.",
 		[]string{"status_path", "instance_id", "title"}, nil)
 


### PR DESCRIPTION
The OpenVPN Access Server business solution uses multiple OpenVPN processes and they can all be queried through a single script - "sacli". I've adapted the JSON output from that script to the existing exporter functionality.